### PR TITLE
Dhs 1504

### DIFF
--- a/tapeArchive/tapeArchive.r
+++ b/tapeArchive/tapeArchive.r
@@ -33,6 +33,9 @@ tapeArchive(*archColl, *counter, *rescParentsLocation, *dataPerResources, *rescP
         *size = 0;
         msi_json_arrayops(*dataArray , "", "size", *size);
 
+        # Get the resource host location
+        *resourceHostLocation= *rescParentsLocation.*srcResourceId;
+
         if ( *size > 0 ){
             # Do a remote execution on *archiveHostLocation
             remote(*archiveHostLocation,"") {
@@ -62,21 +65,22 @@ tapeArchive(*archColl, *counter, *rescParentsLocation, *dataPerResources, *rescP
                        failmsg(-1, "Replication of *ipath from *coordResourceName to *archiveResc FAILED.");
                     }
 
-                    # Trim data from *coordResourceName
-                    msiDataObjTrim(*dataPath, *coordResourceName, "null", "1", "null", *trimStatus);
-                    if ( *trimStatus != 1 ) {
-                       failmsg(-1, "Trim *ipath from *coordResourceName FAILED.");
+                    remote(*resourceHostLocation,"") {
+                        # Trim data from *coordResourceName
+                        msiDataObjTrim(*dataPath, *coordResourceName, "null", "1", "null", *trimStatus);
+                        if ( *trimStatus != 1 ) {
+                           failmsg(-1, "Trim *ipath from *coordResourceName FAILED.");
+                        }
+
+                        # Update counter
+                        *isMoved=*isMoved+1;
+
+                        # Report logs
+                        msiWriteRodsLog("DEBUG: \t\tchksum done *chksum", 0);
+                        msiWriteRodsLog("DEBUG: \t\trepl moveStat done *moveStatus", 0);
+                        msiWriteRodsLog("DEBUG: \t\ttrim stat done *trimStatus", 0);
+                        msiWriteRodsLog("DEBUG: \t\tReplicate from *coordResourceName to *archiveResc", 0);
                     }
-
-                    # Update counter
-                    *isMoved=*isMoved+1;
-
-                    # Report logs
-                    msiWriteRodsLog("DEBUG: \t\tchksum done *chksum", 0);
-                    msiWriteRodsLog("DEBUG: \t\tchksum_repl done *chksum_repl", 0);
-                    msiWriteRodsLog("DEBUG: \t\trepl moveStat done *moveStatus", 0);
-                    msiWriteRodsLog("DEBUG: \t\ttrim stat done *trimStatus", 0);
-                    msiWriteRodsLog("DEBUG: \t\tReplicate from *coordResourceName to *archiveResc", 0);
                 }
             }
         }

--- a/tapeArchive/tapeArchive.r
+++ b/tapeArchive/tapeArchive.r
@@ -38,7 +38,7 @@ tapeArchive(*archColl, *counter, *rescParentsLocation, *dataPerResources, *rescP
 
         if ( *size > 0 ){
             # Do a remote execution on *archiveHostLocation
-            remote(*archiveHostLocation,"") {
+            # remote(*archiveHostLocation,"") {
                 for (*index=0; *index < *size; *index = *index + 1) {
                     # Get the data's path by its index in *dataArray
                     *dataPath = "";
@@ -65,7 +65,7 @@ tapeArchive(*archColl, *counter, *rescParentsLocation, *dataPerResources, *rescP
                        failmsg(-1, "Replication of *ipath from *coordResourceName to *archiveResc FAILED.");
                     }
 
-                    remote(*resourceHostLocation,"") {
+                    # remote(*resourceHostLocation,"") {
                         # Trim data from *coordResourceName
                         msiDataObjTrim(*dataPath, *coordResourceName, "null", "1", "null", *trimStatus);
                         if ( *trimStatus != 1 ) {
@@ -80,8 +80,8 @@ tapeArchive(*archColl, *counter, *rescParentsLocation, *dataPerResources, *rescP
                         msiWriteRodsLog("DEBUG: \t\trepl moveStat done *moveStatus", 0);
                         msiWriteRodsLog("DEBUG: \t\ttrim stat done *trimStatus", 0);
                         msiWriteRodsLog("DEBUG: \t\tReplicate from *coordResourceName to *archiveResc", 0);
-                    }
-                }
+                   # }
+                #}
             }
         }
     }

--- a/tapeArchive/tapeUnArchive.r
+++ b/tapeArchive/tapeUnArchive.r
@@ -114,10 +114,14 @@ tapeUnArchive(*count, *archColl){
                 *value = "unarchive-in-progress "++str(*isMoved+1)++"/"++str(*count);
                 setCollectionAVU(*projectCollectionPath, "archiveState",*value);
 
-                msiDataObjChksum(*ipath,"verifyChksum=",*chksum);
+                # We do not pass any options, this way we get the existing checksum, which should always exist for
+                # archived files. If a failure occurs, the replication is stopped, no trimming happens
+                msiDataObjChksum(*ipath,"=",*chksum);
                 msiWriteRodsLog("DEBUG: surfArchiveScanner archived file *ipath", 0);
 
-                msiDataObjRepl(*ipath, "destRescName=*projectResource++++verifyChksum=", *moveStatus);
+                # Checksum verification is implicit here, because we calculated the checksum already, msiDataObjRepl
+                # will automatically also include a checksum check on the destination
+                msiDataObjRepl(*ipath, "destRescName=*projectResource", *moveStatus);
                 if ( *moveStatus != 0 ) {
                        failmsg(-1, "Replication of *ipath from *coordResourceName to *archiveResc FAILED.");
                 }

--- a/tapeArchive/tapeUnArchive.r
+++ b/tapeArchive/tapeUnArchive.r
@@ -116,7 +116,7 @@ tapeUnArchive(*count, *archColl){
 
                 # We do not pass any options, this way we get the existing checksum, which should always exist for
                 # archived files. If a failure occurs, the replication is stopped, no trimming happens
-                msiDataObjChksum(*ipath,"=",*chksum);
+                msiDataObjChksum(*ipath,"",*chksum);
                 msiWriteRodsLog("DEBUG: surfArchiveScanner archived file *ipath", 0);
 
                 # Checksum verification is implicit here, because we calculated the checksum already, msiDataObjRepl

--- a/tapeArchive/tapeUnArchive.r
+++ b/tapeArchive/tapeUnArchive.r
@@ -68,10 +68,14 @@ tapeUnArchive(*count, *archColl){
                 *value = "unarchive-in-progress "++str(*isMoved+1)++"/"++str(*count);
                 setCollectionAVU(*projectCollectionPath, "archiveState",*value);
 
-                msiDataObjChksum(*ipath,"verifyChksum=",*chksum);
+                # We do not pass any options, this way we get the existing checksum, which should always exist for
+                # archived files. If a failure occurs, the replication is stopped, no trimming happens
+                msiDataObjChksum(*ipath,"",*chksum);
                 msiWriteRodsLog("DEBUG: surfArchiveScanner archived file *ipath", 0);
 
-                msiDataObjRepl(*ipath, "destRescName=*projectResource++++verifyChksum=", *moveStatus);
+                # Checksum verification is implicit here, because we calculated the checksum already, msiDataObjRepl
+                # will automatically also include a checksum check on the destination
+                msiDataObjRepl(*ipath, "destRescName=*projectResource", *moveStatus);
                 if ( *moveStatus != 0 ) {
                        failmsg(-1, "Replication of *ipath from *coordResourceName to *archiveResc FAILED.");
                 }

--- a/tapeArchive/tapeUnArchiveFile.r
+++ b/tapeArchive/tapeUnArchiveFile.r
@@ -8,10 +8,14 @@ tapeUnArchiveFile(*ScanColl, *archiveResc, *projectResource, *resourceLocation, 
         *value = "unarchive-in-progress "++str(*isMoved+1)++"/"++str(*count);
         setCollectionAVU(*archColl, "archiveState",*value);
 
-        msiDataObjChksum(*ipath,"verifyChksum=",*chksum);
+        # We do not pass any options, this way we get the existing checksum, which should always exist for
+        # archived files. If a failure occurs, the replication is stopped, no trimming happens
+        msiDataObjChksum(*ipath,"",*chksum);
         msiWriteRodsLog("DEBUG: surfArchiveScanner archived file *ipath", 0);
 
-        msiDataObjRepl(*ipath, "destRescName=*projectResource++++verifyChksum=", *moveStatus);
+        # Checksum verification is implicit here, because we calculated the checksum already, msiDataObjRepl
+        # will automatically also include a checksum check on the destination
+        msiDataObjRepl(*ipath, "destRescName=*projectResource", *moveStatus);
         if ( *moveStatus != 0 ) {
                failmsg(-1, "Replication of *ipath from *coordResourceName to *archiveResc FAILED.");
         }


### PR DESCRIPTION
In the end the main change of this branch is relatively minor. We've removed all "verifyChksum=" options. This would unnecessary do an extra checksum *before* transferring the file from or to SURF, even if we already had a checksum. We only really need to check *after* transferring.

Removing this, speeds up tape operations quite a bit. Without any extra concern for data loss.