### PR TITLE
Remove -e (editable) flag from dh-python-irods-utils pip install [DHD…

### DIFF
--- a/python/python_requirements.txt
+++ b/python/python_requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/MaastrichtUniversity/dh-python-irods-utils.git@v1.0.0#egg=dh-python-irods-utils
+git+https://github.com/MaastrichtUniversity/dh-python-irods-utils.git@v1.0.0#egg=dh-python-irods-utils
 cryptography
 jsonschema==3.0.2
 pyrsistent==0.16.1


### PR DESCRIPTION
…O-448]

From Luis:

With the 'editable' flag (-e) passed, pip downloads the package in the

current working directory and then proceeds to link to it from the

system directories.

And, if the current working directory happens to be /tmp for example, or

a home directory of a different local user, it would not be possible to

trust that the package will always be available in the system.

Without -e, the package is copied onto the system directories (like:

/usr/local/lib/pythonVERSION/dist-packages ..)