### PR TITLE
Make iRODS use json configuration [DHDO-777]

### DIFF
--- a/native_irods_ruleset/policies/acSetRescSchemeForCreate.r
+++ b/native_irods_ruleset/policies/acSetRescSchemeForCreate.r
@@ -33,7 +33,21 @@ acSetRescSchemeForCreate {
         }
     } else {
         # We are not in a projectfolder at all
-        msiSetDefaultResc("rootResc","null");
+        if($objPath like regex "^/nlmumc/home/rods/tmp.{6,8}demoResc$") {
+            # setup_irods.py will test_put() a temporary file, we reroute to
+            # demoResc instead of rootResc as the latter has not been created
+            # yet at that stage. For iRES(es), setup_irods.py will mkresc its
+            # default resource before doing test_put(). Only iCAT test file
+            # ends in "demoResc".
+            # See: https://github.com/irods/irods/blob/4.2.11/scripts/setup_irods.py#L145
+            #      https://github.com/python/cpython/blob/v2.7/Lib/tempfile.py#L134 (python3 is 8!)
+            # Note: ^ $ seem to be implicit anyway
+            msiWriteRodsLog("acSetRescSchemeForCreate: iCAT setup_irods.py::test_put() detected '$objPath'", 0);
+            msiSetDefaultResc("demoResc","null");
+        } else {
+            # For other files, we set rootResc as the default, as we did before.
+            msiSetDefaultResc("rootResc","null");
+        }
     }
 
     ### Policy to prevent file creation directly in direct ingest folder ###


### PR DESCRIPTION
Make acSetRescSchemeForCreate.r reroute iCAT's setup_irods' test_put() to demoResc

With json_configuration, we load our irods-ruleset before before test_put() in setup_irods.py. Because rootResc does not exist yet, the file test_put() tries to `put` will produce an error.

Note that this only attempts to catch iCAT's test_put file (ends in `demoResc`, default resource name), where json_configuration has:
```
conf['server_config']['default_resource_name'] = 'demoResc'
```

[DHDO-777]

[DHDO-777]: https://mumc.atlassian.net/browse/DHDO-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ