### PR TITLE
Set numThreads to 0 for AZM ingests [DHDO-977]

### DIFF
--- a/native_irods_ruleset/ingest/modifyIngestReSize.r
+++ b/native_irods_ruleset/ingest/modifyIngestReSize.r
@@ -29,6 +29,8 @@ modifyIngestReSize() {
     msiWriteRodsLog("Prevent SYS_HEADER_READ_LENGTH and SYS_HEADER_WRITE_LEN_ERR at approximately 16kB ruleset", 0);
     msiWriteRodsLog("Prevent SYS_HEADER_READ_LENGTH and SYS_HEADER_WRITE_LEN_ERR at approximately 16kB ruleset", 0);
     msiWriteRodsLog("Prevent SYS_HEADER_READ_LENGTH and SYS_HEADER_WRITE_LEN_ERR at approximately 16kB ruleset", 0);
+    msiWriteRodsLog("Prevent SYS_HEADER_READ_LENGTH and SYS_HEADER_WRITE_LEN_ERR at approximately 16kB ruleset", 0);
+    msiWriteRodsLog("Prevent SYS_HEADER_READ_LENGTH and SYS_HEADER_WRITE_LEN_ERR at approximately 16kB ruleset", 0);
 }
 
 INPUT null

--- a/native_irods_ruleset/policies/acSetNumThreads.r
+++ b/native_irods_ruleset/policies/acSetNumThreads.r
@@ -12,7 +12,7 @@ acSetNumThreads {
     *error = errorcode(msiGetValByKey($KVPairs,"rescName",*out));
 
     if ( *error == 0 ) {
-        if ($KVPairs.rescName == "UM-Ceph-S3-AC" || $KVPairs.rescName == "UM-Ceph-S3-GL") {
+        if ($KVPairs.rescName == "UM-Ceph-S3-AC" || $KVPairs.rescName == "UM-Ceph-S3-GL" || $KVPairs.rescName == "AZM-storage" || $KVPairs.rescName == "AZM-storage-repl") {
             msiSetNumThreads("default","0","default");
         } else {
             msiSetNumThreads("default","4","default");


### PR DESCRIPTION
Due to firewall issues in acceptance and production When multithreading it seems to address the source server directly, which is not possible in acc/prod Thus we disable multithreading on AZM for now